### PR TITLE
fix: handle "good til time" limit orders

### DIFF
--- a/src/storage/sqlite3/ingest/ingestTxResponse.ts
+++ b/src/storage/sqlite3/ingest/ingestTxResponse.ts
@@ -16,8 +16,15 @@ import { upsertDerivedTickStateRows } from './tables/derived.tick_state';
 import decodeEvent from './utils/decodeEvent';
 import { getDexMessageAction, isValidResult } from './utils/utils';
 
+let lastHeight = '0';
+let lastTxIndex = 0;
 export default async function ingestTxs(txPage: TxResponse[]) {
-  for (const [index, tx_result] of txPage.entries()) {
+  for (const tx_result of txPage) {
+    // find this transaction's index
+    lastTxIndex = tx_result.height === lastHeight ? lastTxIndex + 1 : 0;
+    lastHeight = tx_result.height;
+    const index = lastTxIndex;
+
     // skip invalid transactions
     if (!isValidResult(tx_result)) {
       continue;


### PR DESCRIPTION
The previous transaction imports could fail when more that one transaction page could be found for each chain block, causing the derive transaction index to not be unique in a given block.

This PR fixes that by ensuring transactions have unique indexes across blocks (to at least the the size of stored integers in SQLite)

This PR assumes that transactions are uniquely ordered, even though there is no explicit index for this. We add the index here for quicker lookups through SQL referenced indexes.