### PR TITLE
feat: add token tick liquidity route

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -4,6 +4,8 @@ import sql from 'sql-template-strings';
 import db from './storage/sqlite3/db/db';
 import logger from './logger';
 
+import liquidityRoutes from './routes/liquidity/token';
+
 import timeseriesPriceRoutes from './routes/timeseries/price';
 import timeseriesVolumeRoutes from './routes/timeseries/volume';
 
@@ -55,6 +57,9 @@ const debugPath = {
 };
 
 const routes = [
+  // liquidity routes
+  ...liquidityRoutes,
+
   // timeseries routes
   ...timeseriesPriceRoutes,
   ...timeseriesVolumeRoutes,

--- a/src/routes/liquidity/token.ts
+++ b/src/routes/liquidity/token.ts
@@ -1,0 +1,30 @@
+import { Request, ResponseToolkit } from '@hapi/hapi';
+
+import logger from '../../logger';
+import getTokenTickLiquidity from '../../storage/sqlite3/db/derived.tick_state/getTickLiquidity';
+
+const routes = [
+  {
+    method: 'GET',
+    path: '/liquidity/token/{tokenA}/{tokenB}',
+    handler: async (request: Request, h: ResponseToolkit) => {
+      try {
+        return await getTokenTickLiquidity(
+          request.params['tokenA'],
+          request.params['tokenB'],
+          request.query // the time extents and frequency and such
+        );
+      } catch (err: unknown) {
+        if (err instanceof Error) {
+          logger.error(err);
+          return h
+            .response(`something happened: ${err.message || '?'}`)
+            .code(500);
+        }
+        return h.response('An unknown error occurred').code(500);
+      }
+    },
+  },
+];
+
+export default routes;

--- a/src/storage/sqlite3/db/derived.tick_state/getTickLiquidity.ts
+++ b/src/storage/sqlite3/db/derived.tick_state/getTickLiquidity.ts
@@ -1,0 +1,113 @@
+import BigNumber from 'bignumber.js';
+import sql from 'sql-template-strings';
+
+import db from '../db';
+import hasInvertedOrder from '../dex.pairs/hasInvertedOrder';
+import {
+  PaginatedRequestQuery,
+  PaginatedResponse,
+  getPaginationFromQuery,
+} from '../paginationUtils';
+
+type DataRow = [tick_index: number, reserves: number];
+
+interface TickLiquidityResponse extends PaginatedResponse {
+  shape: ['tick_index', 'reserves'];
+  data: Array<DataRow>;
+}
+
+export default async function getTokenTickLiquidity(
+  tokenA: string,
+  tokenB: string,
+  query: PaginatedRequestQuery = {}
+): Promise<TickLiquidityResponse> {
+  // collect pagination keys into a pagination object
+  const [pagination, getPaginationNextKey] = getPaginationFromQuery(query);
+
+  // fetch if the order is inverted to order the data and pages correctly
+  const invertedOrder = await hasInvertedOrder(tokenA, tokenB);
+
+  // prepare statement at run time (after db has been initialized)
+  const data: Array<{ [key: string]: number }> =
+    invertedOrder !== undefined
+      ? (await db.all(
+          sql`
+            SELECT
+              'derived.tick_state'.'TickIndex' as 'tickIndex',
+              'derived.tick_state'.'Reserves' as 'reserves'
+            FROM
+              'derived.tick_state'
+            WHERE (
+              'derived.tick_state'.'related.dex.pair' = (
+                SELECT
+                  'dex.pairs'.'id'
+                FROM
+                  'dex.pairs'
+                WHERE (
+                  'dex.pairs'.'token0' = ${tokenA} AND
+                  'dex.pairs'.'token1' = ${tokenB}
+                ) OR (
+                  'dex.pairs'.'token1' = ${tokenA} AND
+                  'dex.pairs'.'token0' = ${tokenB}
+                )
+              ) AND
+              'derived.tick_state'.'related.dex.token' = (
+                SELECT
+                  'dex.tokens'.'id'
+                FROM
+                  'dex.tokens'
+                WHERE (
+                  'dex.tokens'.'Token' = ${tokenA}
+                )
+              ) AND
+              'derived.tick_state'.'Reserves' != '0'
+            )`.append(`--sql
+              -- add dynamic ordering
+              ORDER BY 'derived.tick_state'.'TickIndex' ${
+                invertedOrder ? 'ASC' : 'DESC'
+              }
+            `).append(`--sql
+              -- add pagination
+              LIMIT ${pagination.limit + 1}
+              OFFSET ${pagination.offset}
+            `)
+        )) ?? []
+      : [];
+
+  // if result includes an item from the next page then remove it
+  // and generate a next key to represent the next page of data
+  const nextKey =
+    data.length > pagination.limit
+      ? (() => {
+          // remove data item intended for next page
+          data.pop();
+          // create next page pagination options to be serialized
+          return getPaginationNextKey(data.length);
+        })()
+      : null;
+
+  return {
+    shape: ['tick_index', 'reserves'],
+    data: data.map(
+      // invert the indexes depending on which price ratio was asked for
+      // tick_index is tickIndexBtoA
+      // return reserves as a number (of smaller precision to save bytes)
+      invertedOrder
+        ? (row): DataRow => {
+            return [
+              -row['tickIndex'],
+              Number(new BigNumber(row['reserves']).toPrecision(3)),
+            ];
+          }
+        : (row): DataRow => {
+            return [
+              row['tickIndex'],
+              Number(new BigNumber(row['reserves']).toPrecision(3)),
+            ];
+          }
+    ),
+    pagination: {
+      next_key: nextKey,
+    },
+  };
+}


### PR DESCRIPTION
This PR adds a simple data fetching route for tick liquidity of `tokenA` in a pair of `tokenA<>tokenB` using path `/liquidity/token/{tokenA}/{tokenB}`, the tick indexes returned here would be of the form `tickIndexBToA`.

To fetch the tokenB side it is expected that a front end client should fetch with a path of `/liquidity/token/{tokenB}/{tokenA}`, the result will have inverted tickIndexes as this endpoint would return tick indexes of `tickIndexAToB`.