### PR TITLE
feat: add SQLite WAL mode for faster writes

### DIFF
--- a/.env
+++ b/.env
@@ -3,6 +3,8 @@ NODE_ENV=production
 
 # Database file path
 DB_FILENAME=/tmp/database.db
+# Enable write-ahead-log mode: https://sqlite.org/wal.html
+WAL=1
 
 # Chain endpoints
 REST_API=https://lcd.dev.duality.xyz

--- a/src/storage/sqlite3/db/db.ts
+++ b/src/storage/sqlite3/db/db.ts
@@ -1,7 +1,7 @@
 import sqlite3 from 'sqlite3';
 import { Database } from 'sqlite';
 
-const { NODE_ENV, DB_FILENAME = '/tmp/database.db' } = process.env;
+const { NODE_ENV, DB_FILENAME = '/tmp/database.db', WAL = '' } = process.env;
 
 if (NODE_ENV === 'development') {
   sqlite3.verbose();
@@ -14,6 +14,10 @@ export const db = new Database({
 
 export async function init() {
   await db.open();
+  if (WAL) {
+    // enable WAL mode (significantly faster for many frequent write to file)
+    await db.exec('PRAGMA journal_mode=WAL;');
+  }
 }
 
 export default db;


### PR DESCRIPTION
In SQLite3 WAL mode isn't enabled by default, it is turned on by the specific statement:
```sql
PRAGMA journal_mode=WAL;
```
https://www.sqlite.org/wal.html

In some quick tests this reduced the time to import files by about half when writing to a file. It did not seem to affect import times when in SQLite was in memory-only mode (env var `DB_FILENAME=:memory:`). 