### PR TITLE
chore: improve indexer docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,9 @@ RUN npm i --no-save sqlite3
 # Copy over build files from build-env
 COPY --from=build-env /usr/workspace/dist /usr/workspace/dist
 
-# Copy root-level SSL certs if defined
-COPY --from=build-env /usr/workspace/*.pem /usr/workspace
+# Copy SSL certs if defined from given SSL_FILES_DIRECTORY, or defaulting to CWD
+ARG SSL_FILES_DIRECTORY=/
+COPY --from=build-env /usr/workspace$SSL_FILES_DIRECTORY*.pem /usr/workspace$SSL_FILES_DIRECTORY
 
 # start node
 CMD node dist/server.js


### PR DESCRIPTION
This PR adds a Docker build stage with a smaller final image size due to only including files necessary to run the application.