### PR TITLE
fix: docker compose dev builds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
   indexer:
     build:
       context: .
+      target: build-env
       args:
         - NODE_ENV=development
     command: 'npm run dev'


### PR DESCRIPTION
This is a fix on PR:
- #48

The `docker compose up --build` command had stopped working because the custom command `npm run dev` was being run on a slimmed image that did not have `npm`