### PR TITLE
fix: add Fee to liquidity DB data

### DIFF
--- a/src/storage/sqlite3/db/derived.tick_state/getTickLiquidity.ts
+++ b/src/storage/sqlite3/db/derived.tick_state/getTickLiquidity.ts
@@ -55,7 +55,8 @@ export const tickLiquidityCache: PolicyOptions<TickLiquidity> = {
           )})
             SELECT
               'latest.derived.tick_state'.'TickIndex' as 'tickIndex',
-              'latest.derived.tick_state'.'Reserves' as 'reserves'
+              -- sum reserves for all found unique Fee rows of each TickIndex
+              SUM( CAST('latest.derived.tick_state'.'Reserves') AS FLOAT ) as 'reserves'
             FROM
               'latest.derived.tick_state'
             ${

--- a/src/storage/sqlite3/db/derived.tick_state/selectLatestDerivedTickState.ts
+++ b/src/storage/sqlite3/db/derived.tick_state/selectLatestDerivedTickState.ts
@@ -26,7 +26,7 @@ export default function selectLatestTickState(
         'derived.tick_state'.'related.block.header.height' > ${fromHeight} AND
         'derived.tick_state'.'related.block.header.height' <= ${toHeight}
       )
-      GROUP BY 'derived.tick_state'.'TickIndex'
+      GROUP BY 'derived.tick_state'.'TickIndex', 'derived.tick_state'.'Fee'
       HAVING max('derived.tick_state'.'related.block.header.height')
   `;
 }

--- a/src/storage/sqlite3/ingest/tables/derived.tick_state.ts
+++ b/src/storage/sqlite3/ingest/tables/derived.tick_state.ts
@@ -40,6 +40,8 @@ export async function upsertDerivedTickStateRows(
           'latest.derived.tick_state'.'TickIndex' = ${
             txEvent.attributes['TickIndex']
           }
+        ) AND (
+          'latest.derived.tick_state'.'Fee' = ${txEvent.attributes['Fee']}
         )
         ORDER BY 'latest.derived.tick_state'.'related.block.header.height' DESC
         LIMIT 1
@@ -60,6 +62,7 @@ export async function upsertDerivedTickStateRows(
       ...prepare(sql`
       INSERT OR REPLACE INTO 'derived.tick_state' (
         'TickIndex',
+        'Fee',
         'Reserves',
 
         'related.dex.pair',
@@ -68,6 +71,7 @@ export async function upsertDerivedTickStateRows(
       ) values (
 
         ${txEvent.attributes['TickIndex']},
+        ${txEvent.attributes['Fee']},
         ${txEvent.attributes['Reserves']},
 
         (${selectSortedPairID(

--- a/src/storage/sqlite3/schema/tables/derived.tick_state.sql
+++ b/src/storage/sqlite3/schema/tables/derived.tick_state.sql
@@ -6,6 +6,7 @@
 CREATE TABLE 'derived.tick_state' (
 
   'TickIndex' INTEGER NOT NULL,
+  'Fee' INTEGER NOT NULL,
   'Reserves' TEXT NOT NULL,
 
   'related.dex.pair' INTEGER NOT NULL,
@@ -24,12 +25,13 @@ CREATE TABLE 'derived.tick_state' (
 
 /* add unique index for tick state to ensure no duplicate tick state */
 CREATE UNIQUE INDEX
-  'derived.tick_state--related.dex.pair,related.dex.token,TickIndex,related.block.header.height'
+  'derived.tick_state--related.dex.pair,related.dex.token,TickIndex,Fee,related.block.header.height'
 ON
   'derived.tick_state' (
     'related.dex.pair',
     'related.dex.token',
     'TickIndex',
+    'Fee',
     'related.block.header.height'
   );
 


### PR DESCRIPTION
The liquidity reserve value being set from `TickUpdate` events is specific to the given index & fee: so it must be stored against this fee

Previously it was not, which would have been more of an issue if the PriceBot had been attempting to use multiple fees