### PR TITLE
fix: tick liquidity calculations in tick liquidity fetching

### DIFF
--- a/src/storage/sqlite3/db/derived.tick_state/selectLatestDerivedTickState.ts
+++ b/src/storage/sqlite3/db/derived.tick_state/selectLatestDerivedTickState.ts
@@ -30,3 +30,30 @@ export default function selectLatestTickState(
       HAVING max('derived.tick_state'.'related.block.header.height')
   `;
 }
+
+export function selectTickIndexesOfTickState(
+  token0: string,
+  token1: string,
+  token: string,
+  {
+    fromHeight,
+    toHeight,
+  }: {
+    fromHeight: number;
+    toHeight: number;
+  }
+) {
+  return sql`
+      SELECT 'derived.tick_state'.'TickIndex'
+      FROM 'derived.tick_state'
+      WHERE (
+        'derived.tick_state'.'related.dex.pair' = (${selectSortedPairID(
+          token0,
+          token1
+        )}) AND
+        'derived.tick_state'.'related.dex.token' = (${selectTokenID(token)}) AND
+        'derived.tick_state'.'related.block.header.height' > ${fromHeight} AND
+        'derived.tick_state'.'related.block.header.height' <= ${toHeight}
+      )
+  `;
+}


### PR DESCRIPTION
This fixes a silly SQL syntax error and then several incorrect calculations from 
- #52 

This is due to not enough care being taken during the original work.

The current tick liquidity queries need to handle that the `reserves` in question are now spread across multiple `Fee` rows for any given `TickIndex` in question. So in particular update queries where only one `Fee` and row are effected, care must be taken that the returned `reserves` number is the reserves of the whole `TickIndex` and not just part of the tick index reserves that changed recently. 