### PR TITLE
fix: order of tick pair liquidity

### DIFF
--- a/src/storage/sqlite3/db/derived.tick_state/getTokenPairLiquidity.ts
+++ b/src/storage/sqlite3/db/derived.tick_state/getTokenPairLiquidity.ts
@@ -36,7 +36,7 @@ export async function getHeightedTokenPairLiquidity(
   // return the response data in the correct order
   const height = Number(toHeight);
   if (height > 0 && tickStateA !== null && tickStateB !== null) {
-    return [height, tickStateB, tickStateA];
+    return [height, tickStateA, tickStateB];
   } else {
     return null;
   }


### PR DESCRIPTION
this was caused by a copy-paste error on:
- https://github.com/duality-labs/hapi-indexer/pull/29/commits/d4d422af7d817fc875c8b3a883eb71e4e44bbff9#diff-c7480fed682bd1b661f13669b2ec1ea896f53ad9c5ce8ba12037413ea5ce1c3bL144-R54

and is causing confusing results in the current dev environment, with tokens seemingly being swapped over when they are not. 