### PR TITLE
feat: make block_range related query params more consistent

### DIFF
--- a/API.md
+++ b/API.md
@@ -69,7 +69,9 @@ All liquidity and time series endpoints accept the following query parameters to
   - `pagination.count_total`: return item count (boolean) (not relevant to streams)
 - additional block range query parameters
   - `block_range.from_timestamp`: limits data to blocks after this timestamp
+    - `pagination.after` is an aliased deprecated key for this
   - `block_range.to_timestamp`: limits data to blocks before or equal to this timestamp
+    - `pagination.before` is an aliased deprecated key for this
   - `block_range.from_height`: limits data to blocks after to this height
   - `block_range.to_height`: limits data to blocks before or equal to this height
 

--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ CosmosSDK:
 
 but we also add in new standard pagination parameters for timeseries timestamp limits:
 
-- `pagination.before`
-- `pagination.after`
+- `block_range.from_height`
+- `block_range.to_height`
 
 ### Serving Real-Time Data (long-polling)
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,9 @@ CosmosSDK:
 but we also add in new standard pagination parameters for timeseries timestamp limits:
 
 - `block_range.from_height`
+  - `pagination.after` is an aliased deprecated key for this
 - `block_range.to_height`
+  - `pagination.before` is an aliased deprecated key for this
 
 ### Serving Real-Time Data
 

--- a/src/mechanisms/long-polling.ts
+++ b/src/mechanisms/long-polling.ts
@@ -65,8 +65,6 @@ export default async function longPollRequest<
         // get current data
         data = await getData(request.params, request.query, h.context);
       }
-    } else {
-      return h.response('Cannot wait for future start height').code(400);
     }
 
     // return errors if needed

--- a/src/mechanisms/long-polling.ts
+++ b/src/mechanisms/long-polling.ts
@@ -47,6 +47,7 @@ export default async function longPollRequest<
     if (blockRange.from_height < lastBlockHeight) {
       data = await getData(request.params, request.query, h.context);
     }
+    // prevent requests the start from a future height: they could wait forever
     if (blockRange.from_height > lastBlockHeight) {
       return h.response('Cannot wait for future start height').code(400);
     }

--- a/src/mechanisms/long-polling.ts
+++ b/src/mechanisms/long-polling.ts
@@ -47,7 +47,7 @@ export default async function longPollRequest<
     if (blockRange.from_height < lastBlockHeight) {
       data = await getData(request.params, request.query, h.context);
     }
-    // prevent requests the start from a future height: they could wait forever
+    // prevent requests that start from a future height: they could wait forever
     if (blockRange.from_height > lastBlockHeight) {
       return h.response('Cannot wait for future start height').code(400);
     }

--- a/src/mechanisms/server-sent-events.ts
+++ b/src/mechanisms/server-sent-events.ts
@@ -39,15 +39,17 @@ export default async function serverSentEventRequest<
 ): Promise<void> {
   const {
     from_height: fromHeight = 0,
-    to_height: toHeight = request.query['pagination.before']
-      ? // note: this pagination limit translation of "before" -> "to_height"
+    to_height: toHeight = request.query['block_range.to_timestamp']
+      ? // note: this limit translation of "to_timestamp" -> "to_height"
         //       will not resolve future timestamp blocks correctly (as they
         //       do not exist yet), and will resolve the current block height
         // todo: a better way to track "getData() time" than height would allow
         //       a better condition check as to when to exit the response loop
-        //       and allow a 'pagination.before' future timestamp to behave
+        //       and allow a 'to_timestamp' future time to be used and behave
         //       as expected and end when the time has passed (in block data)
-        await getCompletedHeightAtTime(request.query['pagination.before'])
+        await getCompletedHeightAtTime(
+          request.query['block_range.to_timestamp']
+        )
       : Number.POSITIVE_INFINITY,
   } = getBlockRange(request.query);
 

--- a/src/routes/stats/price.ts
+++ b/src/routes/stats/price.ts
@@ -46,8 +46,8 @@ const getData: GetEndpointData<Plugins, DataSets> = async (
     params['tokenB'],
     'day',
     {
-      'pagination.before': `${mostRecentMinuteUnix}`,
-      'pagination.after': `${mostRecentMinuteUnix - 48 * hours}`,
+      'block_range.to_timestamp': `${mostRecentMinuteUnix}`,
+      'block_range.from_timestamp': `${mostRecentMinuteUnix - 48 * hours}`,
     },
     'last24Hours'
   );

--- a/src/routes/stats/volatility.ts
+++ b/src/routes/stats/volatility.ts
@@ -49,8 +49,8 @@ const getData: GetEndpointData<Plugins, DataSets> = async (
     params['tokenB'],
     'day',
     {
-      'pagination.before': `${nowUnix}`,
-      'pagination.after': `${nowUnix - 22 * days}`,
+      'block_range.to_timestamp': `${nowUnix}`,
+      'block_range.from_timestamp': `${nowUnix - 22 * days}`,
     }
   );
 

--- a/src/routes/stats/volume.ts
+++ b/src/routes/stats/volume.ts
@@ -44,8 +44,10 @@ const routes = [
               params['tokenB'],
               'day',
               {
-                'pagination.before': `${mostRecentMinuteUnix}`,
-                'pagination.after': `${mostRecentMinuteUnix - 48 * hours}`,
+                'block_range.to_timestamp': `${mostRecentMinuteUnix}`,
+                'block_range.from_timestamp': `${
+                  mostRecentMinuteUnix - 48 * hours
+                }`,
               },
               'last24Hours'
             );
@@ -91,8 +93,10 @@ const routes = [
               params['tokenB'],
               'day',
               {
-                'pagination.before': `${mostRecentMinuteUnix}`,
-                'pagination.after': `${mostRecentMinuteUnix - 48 * hours}`,
+                'block_range.to_timestamp': `${mostRecentMinuteUnix}`,
+                'block_range.from_timestamp': `${
+                  mostRecentMinuteUnix - 48 * hours
+                }`,
               },
               'last24Hours'
             );

--- a/src/storage/sqlite3/db/blockRangeUtils.ts
+++ b/src/storage/sqlite3/db/blockRangeUtils.ts
@@ -1,9 +1,20 @@
 import { RequestQuery } from '@hapi/hapi';
+import { getCompletedHeightAtTime } from './block/getHeight';
+import { getLastBlockHeight } from '../../../sync';
 
 export interface BlockRangeRequestQuery extends RequestQuery {
   // custom query parameters
+  'block_range.from_timestamp'?: string; // unix timestamp
+  'block_range.to_timestamp'?: string; // unix timestamp
   'block_range.from_height'?: string; // integer
   'block_range.to_height'?: string; // integer
+}
+
+interface BlockRangeInput {
+  from_timestamp?: number; // unix timestamp from (non-incluse)
+  to_timestamp?: number; // unix timestamp to (non-incluse)
+  from_height?: number; // range from (non-incluse)
+  to_height?: number; // range to (non-incluse)
 }
 
 // a block range is: `from_height` (non-inclusive) -> `to_height` (inclusive)
@@ -11,18 +22,18 @@ export interface BlockRangeRequestQuery extends RequestQuery {
 // and craft a range that adds to that known height to reach a new `to_height`
 export interface BlockRange {
   from_height: number; // range from (non-incluse)
-  to_height: number; // range to (inclusive)
+  to_height: number; // range to (incluse)
 }
 
 export interface BlockRangeResponse {
   block_range: BlockRange;
 }
 
-export function getBlockRange(
-  query: BlockRangeRequestQuery
-): Partial<BlockRange> {
+function getBlockRangeInput(query: BlockRangeRequestQuery): BlockRangeInput {
   // collect possible keys into a user given object
-  const unsafeRequest: Partial<BlockRange> = {
+  const unsafeRequest: Partial<BlockRangeInput> = {
+    from_timestamp: Number(query['block_range.from_timestamp']) || undefined,
+    to_timestamp: Number(query['block_range.to_timestamp']) || undefined,
     from_height: Number(query['block_range.from_height']) || undefined,
     to_height: Number(query['block_range.to_height']) || undefined,
   };
@@ -31,7 +42,50 @@ export function getBlockRange(
   return {
     // ensure number is positive
     // treat "0" as "no height set"
+    from_timestamp: Math.max(0, unsafeRequest.from_timestamp ?? 0) || undefined,
+    to_timestamp: Math.max(0, unsafeRequest.to_timestamp ?? 0) || undefined,
     from_height: Math.max(0, unsafeRequest.from_height ?? 0) || undefined,
     to_height: Math.max(0, unsafeRequest.to_height ?? 0) || undefined,
+  };
+}
+
+// find the resolved block range that we wish to query
+// todo: add some sort of restrictions so that we don't fetch millions of rows
+//       eg. split up requests into smaller more cacheable chunks of data
+export async function getBlockRange(
+  query: BlockRangeRequestQuery,
+  {
+    // by default set query to known data
+    maximumQueryBlockHeight = getLastBlockHeight(),
+  } = {}
+): Promise<BlockRange> {
+  // get input in usable form
+  const blockRangeInput = getBlockRangeInput(query);
+
+  // determine block heights from given height or derived from timestamps or not
+  // note: this limit translation of "to_timestamp" -> "to_height"
+  //       will not resolve future timestamp blocks correctly (as they
+  //       do not exist yet), and will resolve the current block height
+  // todo: a better way to track "getData() time" than height would allow
+  //       a better condition check as to when to exit the response loop
+  //       and allow a 'to_timestamp' future time to be used and behave
+  //       as expected and end when the time has passed (in block data)
+  return {
+    from_height: blockRangeInput.from_height
+      ? // get block from given block
+        Math.min(maximumQueryBlockHeight, blockRangeInput.from_height)
+      : blockRangeInput.from_height
+      ? // get block from timestamp
+        await getCompletedHeightAtTime(blockRangeInput.from_height)
+      : // default to querying from first block
+        0,
+    to_height: blockRangeInput.to_height
+      ? // get block from given block
+        Math.min(maximumQueryBlockHeight, blockRangeInput.to_height)
+      : blockRangeInput.to_height
+      ? // get block from timestamp
+        await getCompletedHeightAtTime(blockRangeInput.to_height)
+      : // default to querying up to last processed block
+        maximumQueryBlockHeight,
   };
 }

--- a/src/storage/sqlite3/db/blockRangeUtils.ts
+++ b/src/storage/sqlite3/db/blockRangeUtils.ts
@@ -60,7 +60,12 @@ export async function getBlockRange(
   } = {}
 ): Promise<BlockRange> {
   // get input in usable form
-  const blockRangeInput = getBlockRangeInput(query);
+  const {
+    from_height: fromHeight,
+    to_height: toHeight,
+    from_timestamp: fromTimestamp,
+    to_timestamp: toTimestamp,
+  } = getBlockRangeInput(query);
 
   // determine block heights from given height or derived from timestamps or not
   // note: this limit translation of "to_timestamp" -> "to_height"
@@ -71,20 +76,20 @@ export async function getBlockRange(
   //       and allow a 'to_timestamp' future time to be used and behave
   //       as expected and end when the time has passed (in block data)
   return {
-    from_height: blockRangeInput.from_height
+    from_height: fromHeight
       ? // get block from given block
-        Math.min(maximumQueryBlockHeight, blockRangeInput.from_height)
-      : blockRangeInput.from_timestamp
+        Math.min(maximumQueryBlockHeight, fromHeight)
+      : fromTimestamp
       ? // get block from timestamp
-        await getCompletedHeightAtTime(blockRangeInput.from_timestamp)
+        await getCompletedHeightAtTime(fromTimestamp)
       : // default to querying from first block
         0,
-    to_height: blockRangeInput.to_height
+    to_height: toHeight
       ? // get block from given block
-        Math.min(maximumQueryBlockHeight, blockRangeInput.to_height)
-      : blockRangeInput.to_timestamp
+        Math.min(maximumQueryBlockHeight, toHeight)
+      : toTimestamp
       ? // get block from timestamp
-        await getCompletedHeightAtTime(blockRangeInput.to_timestamp)
+        await getCompletedHeightAtTime(toTimestamp)
       : // default to querying up to last processed block
         maximumQueryBlockHeight,
   };

--- a/src/storage/sqlite3/db/blockRangeUtils.ts
+++ b/src/storage/sqlite3/db/blockRangeUtils.ts
@@ -74,17 +74,17 @@ export async function getBlockRange(
     from_height: blockRangeInput.from_height
       ? // get block from given block
         Math.min(maximumQueryBlockHeight, blockRangeInput.from_height)
-      : blockRangeInput.from_height
+      : blockRangeInput.from_timestamp
       ? // get block from timestamp
-        await getCompletedHeightAtTime(blockRangeInput.from_height)
+        await getCompletedHeightAtTime(blockRangeInput.from_timestamp)
       : // default to querying from first block
         0,
     to_height: blockRangeInput.to_height
       ? // get block from given block
         Math.min(maximumQueryBlockHeight, blockRangeInput.to_height)
-      : blockRangeInput.to_height
+      : blockRangeInput.to_timestamp
       ? // get block from timestamp
-        await getCompletedHeightAtTime(blockRangeInput.to_height)
+        await getCompletedHeightAtTime(blockRangeInput.to_timestamp)
       : // default to querying up to last processed block
         maximumQueryBlockHeight,
   };

--- a/src/storage/sqlite3/db/blockRangeUtils.ts
+++ b/src/storage/sqlite3/db/blockRangeUtils.ts
@@ -11,18 +11,18 @@ export interface BlockRangeRequestQuery extends RequestQuery {
 }
 
 interface BlockRangeInput {
-  from_timestamp?: number; // unix timestamp from (non-incluse)
-  to_timestamp?: number; // unix timestamp to (non-incluse)
-  from_height?: number; // range from (non-incluse)
-  to_height?: number; // range to (non-incluse)
+  from_timestamp?: number; // unix timestamp from (non-inclusive)
+  to_timestamp?: number; // unix timestamp to (inclusive)
+  from_height?: number; // range from (non-inclusive)
+  to_height?: number; // range to (inclusive)
 }
 
 // a block range is: `from_height` (non-inclusive) -> `to_height` (inclusive)
 // this is so we can start at a known height `from_height`
 // and craft a range that adds to that known height to reach a new `to_height`
 export interface BlockRange {
-  from_height: number; // range from (non-incluse)
-  to_height: number; // range to (incluse)
+  from_height: number; // range from (non-inclusive)
+  to_height: number; // range to (inclusive)
 }
 
 export interface BlockRangeResponse {

--- a/src/storage/sqlite3/db/derived.tick_state/getTokenPairsLiquidity.ts
+++ b/src/storage/sqlite3/db/derived.tick_state/getTokenPairsLiquidity.ts
@@ -101,13 +101,10 @@ export async function getHeightedTokenPairsLiquidity(
   context: Plugins
 ): Promise<HeightedTokenPairsLiquidity | null> {
   const { tokenPairsLiquidityCache, cachedTokenPrices, cachedAssets } = context;
-  const {
-    from_height: fromHeight = 0,
-    to_height: toHeight = getLastBlockHeight(),
-  } = getBlockRange(query);
+  const blockRange = await getBlockRange(query);
 
   // get liquidity state through cache
-  const cacheID = [fromHeight, toHeight].join('|');
+  const cacheID = [blockRange.from_height, blockRange.to_height].join('|');
   const [tokenPairsLiquidity, tokenPrices] = await Promise.all([
     tokenPairsLiquidityCache.get(cacheID),
     cachedTokenPrices?.get(),
@@ -162,7 +159,7 @@ export async function getHeightedTokenPairsLiquidity(
           ],
         ];
       });
-    return [toHeight, sortedtokenPairsLiquidity];
+    return [blockRange.to_height, sortedtokenPairsLiquidity];
   } else {
     return null;
   }

--- a/src/storage/sqlite3/db/derived.tx_price_data/getPrice.ts
+++ b/src/storage/sqlite3/db/derived.tx_price_data/getPrice.ts
@@ -194,9 +194,10 @@ export async function getPairPriceTimeseries(
   // todo: add some sort of restrictions so that we don't fetch millions of rows
   const currentHeight = getLastBlockHeight();
   const [fromHeight = 0, toHeight = currentHeight] = await Promise.all([
-    // prioritize block_range over pagination query params
-    blockRange.from_height ?? getCompletedHeightAtTime(pagination.after),
-    blockRange.to_height ?? getCompletedHeightAtTime(pagination.before),
+    // prioritize block_range over other pagination query params
+    blockRange.from_height ??
+      getCompletedHeightAtTime(pagination.from_timestamp),
+    blockRange.to_height ?? getCompletedHeightAtTime(pagination.to_timestamp),
   ])
     // restrict heights to the maximum of the last processed block
     // (ie. don't include data from partially ingested blocks)

--- a/src/storage/sqlite3/db/derived.tx_price_data/getPrice.ts
+++ b/src/storage/sqlite3/db/derived.tx_price_data/getPrice.ts
@@ -15,7 +15,6 @@ import {
 } from '../timeseriesUtils';
 import { selectSortedPairID } from '../dex.pairs/selectPairID';
 import { getLastBlockHeight } from '../../../../sync';
-import { getCompletedHeightAtTime } from '../block/getHeight';
 import { getBlockRange } from '../blockRangeUtils';
 import {
   selectTimeUnixAfterBlockHeight,
@@ -188,22 +187,10 @@ export async function getPairPriceTimeseries(
 
   // collect pagination keys into a pagination object
   const [pagination] = getPaginationFromQuery(query);
-  const offsetSeconds = await getOffsetSeconds(pagination, periodOffsetType);
-
-  const blockRange = getBlockRange(query);
-  // todo: add some sort of restrictions so that we don't fetch millions of rows
-  const currentHeight = getLastBlockHeight();
-  const [fromHeight = 0, toHeight = currentHeight] = await Promise.all([
-    // prioritize block_range over other pagination query params
-    blockRange.from_height ??
-      getCompletedHeightAtTime(pagination.from_timestamp),
-    blockRange.to_height ?? getCompletedHeightAtTime(pagination.to_timestamp),
-  ])
-    // restrict heights to the maximum of the last processed block
-    // (ie. don't include data from partially ingested blocks)
-    .then((heights) =>
-      heights.map((height) => Math.min(height, currentHeight))
-    );
+  const [blockRange, offsetSeconds] = await Promise.all([
+    getBlockRange(query),
+    getOffsetSeconds(pagination, periodOffsetType),
+  ]);
 
   // get prices through cache
   const cacheKey = [
@@ -212,11 +199,11 @@ export async function getPairPriceTimeseries(
     tokenIn,
     partitionTimeFormat,
     offsetSeconds,
-    fromHeight,
-    toHeight,
+    blockRange.from_height,
+    blockRange.to_height,
   ].join('|');
   const data = await pairPriceCache.get(cacheKey);
-  return data ? [toHeight, data] : null;
+  return data ? [blockRange.to_height, data] : null;
 }
 
 export async function getUnsortedPairPriceTimeseries(

--- a/src/storage/sqlite3/db/derived.tx_volume_data/getTotalVolume.ts
+++ b/src/storage/sqlite3/db/derived.tx_volume_data/getTotalVolume.ts
@@ -179,9 +179,10 @@ export async function getTotalVolumeTimeseries(
   // todo: add some sort of restrictions so that we don't fetch millions of rows
   const currentHeight = getLastBlockHeight();
   const [fromHeight = 0, toHeight = currentHeight] = await Promise.all([
-    // prioritize block_range over pagination query params
-    blockRange.from_height ?? getCompletedHeightAtTime(pagination.after),
-    blockRange.to_height ?? getCompletedHeightAtTime(pagination.before),
+    // prioritize block_range over other pagination query params
+    blockRange.from_height ??
+      getCompletedHeightAtTime(pagination.from_timestamp),
+    blockRange.to_height ?? getCompletedHeightAtTime(pagination.to_timestamp),
   ])
     // restrict heights to the maximum of the last processed block
     // (ie. don't include data from partially ingested blocks)

--- a/src/storage/sqlite3/db/derived.tx_volume_data/getTotalVolume.ts
+++ b/src/storage/sqlite3/db/derived.tx_volume_data/getTotalVolume.ts
@@ -15,7 +15,6 @@ import {
 } from '../timeseriesUtils';
 import { selectSortedPairID } from '../dex.pairs/selectPairID';
 import { getLastBlockHeight } from '../../../../sync';
-import { getCompletedHeightAtTime } from '../block/getHeight';
 import { getBlockRange } from '../blockRangeUtils';
 import {
   selectTimeUnixAfterBlockHeight,
@@ -173,22 +172,10 @@ export async function getTotalVolumeTimeseries(
 
   // collect pagination keys into a pagination object
   const [pagination] = getPaginationFromQuery(query);
-  const offsetSeconds = await getOffsetSeconds(pagination, periodOffsetType);
-
-  const blockRange = getBlockRange(query);
-  // todo: add some sort of restrictions so that we don't fetch millions of rows
-  const currentHeight = getLastBlockHeight();
-  const [fromHeight = 0, toHeight = currentHeight] = await Promise.all([
-    // prioritize block_range over other pagination query params
-    blockRange.from_height ??
-      getCompletedHeightAtTime(pagination.from_timestamp),
-    blockRange.to_height ?? getCompletedHeightAtTime(pagination.to_timestamp),
-  ])
-    // restrict heights to the maximum of the last processed block
-    // (ie. don't include data from partially ingested blocks)
-    .then((heights) =>
-      heights.map((height) => Math.min(height, currentHeight))
-    );
+  const [blockRange, offsetSeconds] = await Promise.all([
+    getBlockRange(query),
+    getOffsetSeconds(pagination, periodOffsetType),
+  ]);
 
   // get prices through cache
   const cacheKey = [
@@ -197,11 +184,11 @@ export async function getTotalVolumeTimeseries(
     tokenIn,
     partitionTimeFormat,
     offsetSeconds,
-    fromHeight,
-    toHeight,
+    blockRange.from_height,
+    blockRange.to_height,
   ].join('|');
   const data = await totalVolumeCache.get(cacheKey);
-  return data ? [toHeight, data] : null;
+  return data ? [blockRange.to_height, data] : null;
 }
 
 export async function getUnsortedTotalVolumeTimeseries(

--- a/src/storage/sqlite3/db/event.TickUpdate/getSwapVolume.ts
+++ b/src/storage/sqlite3/db/event.TickUpdate/getSwapVolume.ts
@@ -248,9 +248,10 @@ export async function getSwapVolumeTimeseries(
   // todo: add some sort of restrictions so that we don't fetch millions of rows
   const currentHeight = getLastBlockHeight();
   const [fromHeight = 0, toHeight = currentHeight] = await Promise.all([
-    // prioritize block_range over pagination query params
-    blockRange.from_height ?? getCompletedHeightAtTime(pagination.after),
-    blockRange.to_height ?? getCompletedHeightAtTime(pagination.before),
+    // prioritize block_range over other pagination query params
+    blockRange.from_height ??
+      getCompletedHeightAtTime(pagination.from_timestamp),
+    blockRange.to_height ?? getCompletedHeightAtTime(pagination.to_timestamp),
   ])
     // restrict heights to the maximum of the last processed block
     // (ie. don't include data from partially ingested blocks)

--- a/src/storage/sqlite3/db/event.TickUpdate/getSwapVolume.ts
+++ b/src/storage/sqlite3/db/event.TickUpdate/getSwapVolume.ts
@@ -15,7 +15,6 @@ import {
 } from '../timeseriesUtils';
 import { selectSortedPairID } from '../dex.pairs/selectPairID';
 import { getLastBlockHeight } from '../../../../sync';
-import { getCompletedHeightAtTime } from '../block/getHeight';
 import { getBlockRange } from '../blockRangeUtils';
 import {
   selectTimeUnixAfterBlockHeight,
@@ -242,22 +241,10 @@ export async function getSwapVolumeTimeseries(
 
   // collect pagination keys into a pagination object
   const [pagination] = getPaginationFromQuery(query);
-  const offsetSeconds = await getOffsetSeconds(pagination, periodOffsetType);
-
-  const blockRange = getBlockRange(query);
-  // todo: add some sort of restrictions so that we don't fetch millions of rows
-  const currentHeight = getLastBlockHeight();
-  const [fromHeight = 0, toHeight = currentHeight] = await Promise.all([
-    // prioritize block_range over other pagination query params
-    blockRange.from_height ??
-      getCompletedHeightAtTime(pagination.from_timestamp),
-    blockRange.to_height ?? getCompletedHeightAtTime(pagination.to_timestamp),
-  ])
-    // restrict heights to the maximum of the last processed block
-    // (ie. don't include data from partially ingested blocks)
-    .then((heights) =>
-      heights.map((height) => Math.min(height, currentHeight))
-    );
+  const [blockRange, offsetSeconds] = await Promise.all([
+    getBlockRange(query),
+    getOffsetSeconds(pagination, periodOffsetType),
+  ]);
 
   // get prices through cache
   const cacheKey = [
@@ -266,11 +253,11 @@ export async function getSwapVolumeTimeseries(
     tokenIn,
     partitionTimeFormat,
     offsetSeconds,
-    fromHeight,
-    toHeight,
+    blockRange.from_height,
+    blockRange.to_height,
   ].join('|');
   const data = await swapVolumeCache.get(cacheKey);
-  return data ? [toHeight, data] : null;
+  return data ? [blockRange.to_height, data] : null;
 }
 
 export async function getUnsortedSwapVolumeTimeseries(

--- a/src/storage/sqlite3/db/paginationUtils.ts
+++ b/src/storage/sqlite3/db/paginationUtils.ts
@@ -108,7 +108,7 @@ export function getPaginationFromQuery(
         // (for consistent processing)
         before: Number(query['pagination.before']) || undefined,
         after: Number(query['pagination.after']) || undefined,
-        count_total: Boolean(query['pagination.after']) || undefined,
+        count_total: Boolean(query['pagination.count_total']) || undefined,
       });
     }
     // otherwise return no new key

--- a/src/storage/sqlite3/db/paginationUtils.ts
+++ b/src/storage/sqlite3/db/paginationUtils.ts
@@ -8,15 +8,15 @@ export interface PaginatedRequestQuery extends RequestQuery {
   'pagination.limit'?: string; // integer
   'pagination.count_total'?: string; // boolean
   // custom
-  'pagination.before'?: string; // unix timestamp
-  'pagination.after'?: string; // unix timestamp
+  'block_range.from_timestamp'?: string; // unix timestamp
+  'block_range.to_timestamp'?: string; // unix timestamp
 }
 
 export interface PaginationInput {
   offset: number;
   limit: number;
-  before: number; // unix timestamp
-  after: number; // unix timestamp
+  from_timestamp: number; // unix timestamp
+  to_timestamp: number; // unix timestamp
   count_total: boolean;
 }
 
@@ -38,8 +38,8 @@ export function decodePagination(
   let unsafePagination: Partial<PaginationInput> = {
     offset: Number(query['pagination.offset']) || undefined,
     limit: Number(query['pagination.limit']) || undefined,
-    before: Number(query['pagination.before']) || undefined,
-    after: Number(query['pagination.after']) || undefined,
+    from_timestamp: Number(query['block_range.from_timestamp']) || undefined,
+    to_timestamp: Number(query['block_range.to_timestamp']) || undefined,
     count_total: query['pagination.count_total']
       ? query['pagination.count_total'] === 'true'
       : undefined,
@@ -59,8 +59,9 @@ export function decodePagination(
   return {
     offset: Math.max(0, unsafePagination.offset ?? 0),
     limit: Math.min(10000, unsafePagination.limit ?? defaultPageSize),
-    before: unsafePagination.before ?? Math.floor(Date.now() / 1000),
-    after: unsafePagination.after ?? 0,
+    from_timestamp: unsafePagination.from_timestamp ?? 0,
+    to_timestamp:
+      unsafePagination.to_timestamp ?? Math.floor(Date.now() / 1000),
     count_total: unsafePagination.count_total ?? false,
   };
 }
@@ -69,17 +70,15 @@ export function decodePagination(
 const paginationKeys: Array<keyof PaginationInput> = [
   'offset',
   'limit',
-  'before',
-  'after',
+  'from_timestamp',
+  'to_timestamp',
 ];
 function encodePaginationKey(
-  pagination: Partial<PaginationInput | PaginatedRequestQuery>
+  pagination: Partial<PaginationInput>
 ): PaginationOutput['next_key'] {
   // whitelist only expected pagination keys
   const paginationProps = Object.fromEntries(
     Object.entries(pagination)
-      // remove pagination prefix
-      .map(([key, value]) => [key.replace(/^pagination\./, ''), value])
       // remove non-pagination keys
       .filter(([key]) => (paginationKeys as string[]).includes(key))
   );
@@ -106,8 +105,9 @@ export function getPaginationFromQuery(
         limit: pagination.limit,
         // pass height queries back in almost exactly as they came
         // (for consistent processing)
-        before: Number(query['pagination.before']) || undefined,
-        after: Number(query['pagination.after']) || undefined,
+        from_timestamp:
+          Number(query['block_range.from_timestamp']) || undefined,
+        to_timestamp: Number(query['block_range.to_timestamp']) || undefined,
         count_total: Boolean(query['pagination.count_total']) || undefined,
       });
     }
@@ -121,10 +121,10 @@ export function getPaginationFromQuery(
 export function paginateData<T = unknown>(
   data: Array<T>,
   query: PaginatedRequestQuery,
-  defaultPageSize?: number
+  pageSize?: number
 ): [Array<T>, PaginationOutput] {
   // collect pagination keys into a pagination object
-  const { offset, limit } = decodePagination(query, defaultPageSize);
+  const { offset, limit, ...pagination } = decodePagination(query, pageSize);
 
   // get this page
   const nextOffset = offset + limit;
@@ -132,7 +132,7 @@ export function paginateData<T = unknown>(
   // and generate a next key to represent the next page of data
   const nextKey =
     data.length > nextOffset
-      ? encodePaginationKey({ ...query, offset: nextOffset, limit })
+      ? encodePaginationKey({ ...pagination, offset: nextOffset, limit })
       : null;
 
   return [page, { next_key: nextKey, total: data.length }];

--- a/src/storage/sqlite3/db/timeseriesUtils.ts
+++ b/src/storage/sqlite3/db/timeseriesUtils.ts
@@ -48,8 +48,8 @@ async function getStartOfDayOffset(pagination: PaginationInput) {
   const { offset } = await db.get(
     ...prepare(sql`
     SELECT (
-      ${pagination.before} - unixepoch(
-        datetime(${pagination.before}, "unixepoch"),
+      ${pagination.to_timestamp} - unixepoch(
+        datetime(${pagination.to_timestamp}, "unixepoch"),
         "start of day"
       )
     ) as 'offset'

--- a/src/storage/sqlite3/db/timeseriesUtils.ts
+++ b/src/storage/sqlite3/db/timeseriesUtils.ts
@@ -45,11 +45,12 @@ export type Resolution = keyof typeof resolutionTimeFormats;
 
 // calculate how far from the start of day we are in secods
 async function getStartOfDayOffset(pagination: PaginationInput) {
+  const toTimestamp = pagination.to_timestamp || Math.round(Date.now() / 1000);
   const { offset } = await db.get(
     ...prepare(sql`
     SELECT (
-      ${pagination.to_timestamp} - unixepoch(
-        datetime(${pagination.to_timestamp}, "unixepoch"),
+      ${toTimestamp} - unixepoch(
+        datetime(${toTimestamp}, "unixepoch"),
         "start of day"
       )
     ) as 'offset'


### PR DESCRIPTION
This PR changes the query parameters:
- `pagination.before` -> `block_range.from_height`
- `pagination.after` -> `block_range.to_height`

This also reorganizes these query parameters from "pagination" limits to "block_range" limits, and only includes them as pagination limits to generate the expected "next_key" in pagination response properties. 

The PR also refactors much logic of resolving block range timestamp limits into block range heights more consistently and reliably.