### PR TITLE
fix: allow multiple CORS origins to be whitelisted

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,11 @@
 
 NODE_ENV=production
+
+# Server options
 PORT=8000
+# comma separated list as a string
+# see docs: https://hapi.dev/api/?v=21.3.3#-routeoptionscors
+CORS_ALLOWED_ORIGINS=https://*.neutron.org,https://localhost:5173
 
 # Database file path
 DB_FILENAME=/tmp/database.db

--- a/.env
+++ b/.env
@@ -4,8 +4,10 @@ NODE_ENV=production
 # Server options
 # PORT will be overridden to 8000 when running default docker-compose setup
 PORT=8000
-# comma separated list as a string
-# see docs: https://hapi.dev/api/?v=21.3.3#-routeoptionscors
+# CORS origins may be a comma separated list as a string
+# note that "*" may be a wildcard for all origins but may also
+# be used to whitelist an origin pattern, eg. https://*.duality.xyz
+# docs: https://hapi.dev/api/?v=21.3.3#-routeoptionscors
 CORS_ALLOWED_ORIGINS=https://*.neutron.org,https://localhost:5173
 
 # Database file path

--- a/.env
+++ b/.env
@@ -8,7 +8,7 @@ PORT=8000
 # note that "*" may be a wildcard for all origins but may also
 # be used to whitelist an origin pattern, eg. https://*.duality.xyz
 # docs: https://hapi.dev/api/?v=21.3.3#-routeoptionscors
-CORS_ALLOWED_ORIGINS=https://*.neutron.org,https://localhost:5173
+CORS_ALLOWED_ORIGINS=
 
 # Database file path
 DB_FILENAME=/tmp/database.db

--- a/.env
+++ b/.env
@@ -2,6 +2,7 @@
 NODE_ENV=production
 
 # Server options
+# PORT will be overridden to 8000 when running default docker-compose setup
 PORT=8000
 # comma separated list as a string
 # see docs: https://hapi.dev/api/?v=21.3.3#-routeoptionscors

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # install node
 # https://hub.docker.com/_/node/
-FROM node:18-alpine as build-env
+FROM node:18.19-alpine as build-env
 
 RUN apk add openssl
 
@@ -44,7 +44,7 @@ CMD npm start
 
 
 # return slimmer build
-FROM node:18-alpine
+FROM node:18.19-alpine
 
 WORKDIR /usr/workspace
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN NODE_ENV=${NODE_ENV} npm ci
 # copy app source to destination container
 COPY . .
 
-# expose container port
+# expose container port: docker-compose will serve PORT 8000 from this build-env
 EXPOSE 8000
 
 # build bundled code

--- a/README.md
+++ b/README.md
@@ -240,7 +240,10 @@ An example of local development ENV vars is given here:
 NODE_ENV=development
 
 # Allow all CORS origins for development
-CORS_ALLOWED_ORIGIN=*
+CORS_ALLOWED_ORIGINS=*
+# or
+# Allow specific CORS origins for development
+CORS_ALLOWED_ORIGINS=https://app.testnet.duality.xyz,https://localhost:5173
 
 # Connect to local chain served by a Docker container
 # eg. by following the steps of https://docs.neutron.org/neutron/build-and-run/cosmopark

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ NODE_ENV=development
 CORS_ALLOWED_ORIGINS=*
 # or
 # Allow specific CORS origins for development
-CORS_ALLOWED_ORIGINS=https://app.testnet.duality.xyz,https://localhost:5173
+CORS_ALLOWED_ORIGINS=https://*.neutron.org,https://localhost:5173
 
 # Connect to local chain served by a Docker container
 # eg. by following the steps of https://docs.neutron.org/neutron/build-and-run/cosmopark

--- a/README.md
+++ b/README.md
@@ -239,6 +239,9 @@ An example of local development ENV vars is given here:
 # Add dev endpoints
 NODE_ENV=development
 
+# Allow all CORS origins for development
+CORS_ALLOWED_ORIGIN=*
+
 # Connect to local chain served by a Docker container
 # eg. by following the steps of https://docs.neutron.org/neutron/build-and-run/cosmopark
 # - set up local repo folders by cloning from git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     env_file:
       - .env
       - .env.local
+    environment:
+      - PORT=8000
     volumes:
       - ./src:/usr/workspace/src
     ports:

--- a/src/server.ts
+++ b/src/server.ts
@@ -121,6 +121,9 @@ const init = async () => {
     routes: {
       cors: {
         // CORS origins may be a comma separated list as a string
+        // note that "*" may be a wildcard for all origins but may also
+        // be used to whitelist an origin pattern, eg. https://*.duality.xyz
+        // docs: https://hapi.dev/api/?v=21.3.3#-routeoptionscors
         origin: CORS_ALLOWED_ORIGINS.split(',').map((v) => v.trim()),
         headers: ['Accept', 'Content-Type'],
         additionalHeaders: ['X-Requested-With'],

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,11 +22,9 @@ function safeReadFileText(filename: string) {
 }
 
 const {
-  NODE_ENV = 'production',
   PORT = '8000',
   RPC_API = '',
-  // by default allow all CORS origins in non-production environments only
-  CORS_ALLOWED_ORIGIN = NODE_ENV === 'production' ? '' : '*',
+  CORS_ALLOWED_ORIGIN = '',
   ALLOW_ROUTES_BEFORE_SYNCED = '',
   SSL_PRIVATE_KEY_FILE = 'ssl-key.pem',
   SSL_PUBLIC_KEY_FILE = 'ssl-cert.pem',

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,7 +24,7 @@ function safeReadFileText(filename: string) {
 const {
   PORT = '8000',
   RPC_API = '',
-  CORS_ALLOWED_ORIGIN = '',
+  CORS_ALLOWED_ORIGINS = '',
   ALLOW_ROUTES_BEFORE_SYNCED = '',
   SSL_PRIVATE_KEY_FILE = 'ssl-key.pem',
   SSL_PUBLIC_KEY_FILE = 'ssl-cert.pem',
@@ -120,7 +120,8 @@ const init = async () => {
     host: '0.0.0.0',
     routes: {
       cors: {
-        origin: [CORS_ALLOWED_ORIGIN],
+        // CORS origins may be a comma separated list as a string
+        origin: CORS_ALLOWED_ORIGINS.split(',').map((v) => v.trim()),
         headers: ['Accept', 'Content-Type'],
         additionalHeaders: ['X-Requested-With'],
       },


### PR DESCRIPTION
this PR:
- updates Docker base images to the expected node version from `package.json`
- changes `CORS_ALLOWED_ORIGIN` to `CORS_ALLOWED_ORIGINS` to allow a comma separated list
- adds some more explanation of PORT settings when using docker-compose