### PR TITLE
fix: swap high and low values when token order is inverted

### DIFF
--- a/src/storage/sqlite3/db/derived.tx_price_data/getPrice.ts
+++ b/src/storage/sqlite3/db/derived.tx_price_data/getPrice.ts
@@ -162,7 +162,7 @@ export const pairPriceCache: PolicyOptions<DataSet> = {
                 return [
                   row['time_unix'],
                   // invert the indexes for the asked for price ratio
-                  [-row['open'], -row['high'], -row['low'], -row['close']],
+                  [-row['open'], -row['low'], -row['high'], -row['close']],
                 ];
               }
         );


### PR DESCRIPTION
Previously the price in `["open", "high", "low", "close"]` tick index format (`price = 1.0001^tickIndex`) would not make sense if viewing a price timeseries where the tokens are in the reversed order from how they are stored in the database.

Example:
excerpt from `/timeseries/price/A/B`
```json
{
  "shape": [
    ["time_unix", ["open", "high", "low", "close"]]
  ],
  "data": [
    [1703705820, [-12080, -4829, -12080, -4829]]
  ]
}
```

reversed: `/timeseries/price/B/A`
```json
{
  "shape": [
    ["time_unix", ["open", "high", "low", "close"]]
  ],
  "data": [
    [1703705820, [12080, 4829, 12080, 4829]]
  ]
}
```

This PR changes this behavior to give the correct high and low values with the token ratio viewed in both directions.