### PR TITLE
fix: do not skip known indexes in price data table

### DIFF
--- a/src/storage/sqlite3/ingest/tables/derived.tx_price_data.ts
+++ b/src/storage/sqlite3/ingest/tables/derived.tx_price_data.ts
@@ -2,9 +2,8 @@ import sql from 'sql-template-tag';
 import { TxResponse } from '../../../../@types/tx';
 
 import db, { prepare } from '../../db/db';
-import selectLatestTickState from '../../db/derived.tick_state/selectLatestDerivedTickState';
 
-import { DecodedTxEvent } from '../utils/decodeEvent';
+import decodeEvent, { DecodedTxEvent } from '../utils/decodeEvent';
 import Timer from '../../../../utils/timer';
 import { selectSortedPairID } from '../../db/dex.pairs/selectPairID';
 
@@ -20,12 +19,24 @@ export default async function upsertDerivedPriceData(
     txEvent.attributes.module === 'dex' &&
     tx_result.code === 0;
 
-  if (isDexMessage && txEvent.attributes.action === 'TickUpdate') {
+  // only consider TickUpdates for price movements
+  const isDexTickUpdate =
+    isDexMessage && txEvent.attributes.action === 'TickUpdate';
+
+  // only consider TickUpdates from PlaceLimitOrder actions as price movements
+  const isDexTxMsgPlaceLimitOrder =
+    isDexTickUpdate &&
+    (tx_result.events || [])
+      .filter((txEvent) => txEvent.type === 'message')
+      .map(decodeEvent)
+      .find(
+        (txDecodedEvent) =>
+          txDecodedEvent.attributes['action'] === 'PlaceLimitOrder'
+      );
+
+  if (isDexMessage && isDexTickUpdate && isDexTxMsgPlaceLimitOrder) {
     const isForward =
       txEvent.attributes['TokenIn'] === txEvent.attributes['TokenOne'];
-    const tickSide = isForward
-      ? 'LowestNormalizedTickIndex1'
-      : 'HighestNormalizedTickIndex0';
     // note that previousTickIndex may not exist yet
     timer.start('processing:txs:derived.tx_price_data:get:tx_price_data');
     const previousPriceData = await db.get(
@@ -46,35 +57,15 @@ export default async function upsertDerivedPriceData(
       LIMIT 1
       `)
     );
-    const previousTickIndex = previousPriceData?.[tickSide];
     timer.stop('processing:txs:derived.tx_price_data:get:tx_price_data');
 
-    timer.start('processing:txs:derived.tx_price_data:get:tick_state');
     // derive data from entire ticks state (useful for maybe some other calculations)
-    const currentTickIndex: number | null = await db
-      .get(
-        ...prepare(sql`
-          WITH 'latest.derived.tick_state' AS (${selectLatestTickState(
-            txEvent.attributes['TokenZero'],
-            txEvent.attributes['TokenOne'],
-            txEvent.attributes['TokenIn'],
-            { fromHeight: 0, toHeight: Number(tx_result.height) }
-          )})
-          SELECT
-            'latest.derived.tick_state'.'TickIndex'
-          FROM
-            'latest.derived.tick_state'
-          WHERE
-            'latest.derived.tick_state'.'Reserves' != '0'
-          ORDER BY 'latest.derived.tick_state'.'TickIndex' ASC
-          LIMIT 1
-        `)
-      )
-      .then((row) => row && (isForward ? row['TickIndex'] : -row['TickIndex']));
-    timer.stop('processing:txs:derived.tx_price_data:get:tick_state');
+    const currentTickIndex: number | null = txEvent.attributes['TickIndex']
+      ? Number(txEvent.attributes['TickIndex']) * (isForward ? 1 : -1)
+      : null;
 
-    // if activity has changed current price then update data
-    if (previousTickIndex !== currentTickIndex) {
+    // if activity has a current price then update data
+    if (currentTickIndex !== null) {
       const previousOtherSideTickIndex =
         (isForward
           ? previousPriceData?.['HighestNormalizedTickIndex0']

--- a/src/storage/sqlite3/schema/tables/derived.tx_price_data.sql
+++ b/src/storage/sqlite3/schema/tables/derived.tx_price_data.sql
@@ -5,10 +5,8 @@
   */
 CREATE TABLE 'derived.tx_price_data' (
 
-  'HighestNormalizedTickIndex0' INTEGER,
-  'LowestNormalizedTickIndex1' INTEGER,
-  -- last tick (current price tick) may be null if all liquidity is removed
-  'LastTickIndex1To0' INTEGER,
+  -- last tick index that a trade happened on
+  'LastTickIndex1To0' INTEGER NOT NULL,
 
   'related.tx_result.events' INTEGER NOT NULL,
   'related.dex.pair' INTEGER NOT NULL,


### PR DESCRIPTION
This PR attempts to fix the setting of `LastTickIndex1To0` values in the `derived.tx_price_data` table.

Previously an update would be skipped if the price on the specific reserve's side TickIndex (`HighestNormalizedTickIndex0` or `LowestNormalizedTickIndex1` had not changed) had not changed. This is incorrect behavior. 

The original intent of the `HighestNormalizedTickIndex0` and `LowestNormalizedTickIndex1` values was to create a "indicative price" of the pair where a reserve deposit that was "closer to the middle" than any other deposit or previous trade would indicate that the price had changed to that value. This was supposed to be helpful but is not that helpful. It may also even introduce attack vectors where users can influence the recorded price with small deposits at extreme positions.

It is much simpler to keep the definition of price as the last price that a trade occurred on, without accepting prices from any deposit events.

After removing the previous logic, the previous data columns for tracking `HighestNormalizedTickIndex0` and `LowestNormalizedTickIndex1` values were removed. 