### PR TITLE
fix: swap volume calculations

### DIFF
--- a/src/routes/timeseries/volume.ts
+++ b/src/routes/timeseries/volume.ts
@@ -24,8 +24,8 @@ const routes = [
         [
           'time_unix',
           [
-            `amount ${request.params['tokenA']}`,
-            `amount ${request.params['tokenB']}`,
+            `amount (excluding fee) ${request.params['tokenA']}`,
+            `amount (excluding fee) ${request.params['tokenB']}`,
             `fee ${request.params['tokenA']}`,
             `fee ${request.params['tokenB']}`,
           ],

--- a/src/storage/sqlite3/db/event.TickUpdate/getSwapVolume.ts
+++ b/src/storage/sqlite3/db/event.TickUpdate/getSwapVolume.ts
@@ -99,7 +99,7 @@ export const swapVolumeCache: PolicyOptions<DataSet> = {
                   )
                   THEN (
                     CAST('event.TickUpdate'.'derived.ReservesDiff' as FLOAT) *
-                    'event.TickUpdate'.'Fee' / 10000
+                    COALESCE('event.TickUpdate'.'Fee', 0) / 10000
                   )
                   ELSE 0
                 END
@@ -124,7 +124,7 @@ export const swapVolumeCache: PolicyOptions<DataSet> = {
                   )
                   THEN (
                     CAST('event.TickUpdate'.'derived.ReservesDiff' as FLOAT) *
-                    'event.TickUpdate'.'Fee' / 10000
+                    COALESCE('event.TickUpdate'.'Fee', 0) / 10000
                   )
                   ELSE 0
                 END

--- a/src/storage/sqlite3/ingest/tables/event.TickUpdate.ts
+++ b/src/storage/sqlite3/ingest/tables/event.TickUpdate.ts
@@ -54,6 +54,7 @@ export default async function insertEventTickUpdate(
       'TickIndex',
       'Reserves',
       'Fee',
+      'TrancheKey',
 
       'derived.ReservesDiff',
 
@@ -67,11 +68,8 @@ export default async function insertEventTickUpdate(
       ${txEvent.attributes['TokenIn']},
       ${txEvent.attributes['TickIndex']},
       ${txEvent.attributes['Reserves']},
-      ${
-        Number(txEvent.attributes['Fee']) >= 0
-          ? txEvent.attributes['Fee']
-          : null
-      },
+      ${txEvent.attributes['Fee'] || null},
+      ${txEvent.attributes['TrancheKey'] || null},
 
       -- derive the difference in reserves from the previous tick state
       ${

--- a/src/storage/sqlite3/ingest/tables/event.TickUpdate.ts
+++ b/src/storage/sqlite3/ingest/tables/event.TickUpdate.ts
@@ -68,7 +68,9 @@ export default async function insertEventTickUpdate(
       ${txEvent.attributes['TokenIn']},
       ${txEvent.attributes['TickIndex']},
       ${txEvent.attributes['Reserves']},
-      ${txEvent.attributes['Fee'] || null},
+      -- set either TrancheKey or Fee: a Fee where TrancheKey exists is a bug
+      -- see: https://github.com/neutron-org/neutron/pull/473
+      ${txEvent.attributes['TrancheKey'] ? null : txEvent.attributes['Fee']},
       ${txEvent.attributes['TrancheKey'] || null},
 
       -- derive the difference in reserves from the previous tick state

--- a/src/storage/sqlite3/schema/tables/event.TickUpdate.sql
+++ b/src/storage/sqlite3/schema/tables/event.TickUpdate.sql
@@ -12,8 +12,9 @@ CREATE TABLE 'event.TickUpdate' (
   -- TickIndex here is TickIndexTakerToMaker (ie. "in to out" or "out per in")
   'TickIndex' INTEGER NOT NULL,
   'Reserves' TEXT NOT NULL,
-  -- fees do not exist for all TickUpdate events
+  -- TickUpdate may include a fee (reserves on Dex) or TrancheKey (reserves in a tranche), but not both
   'Fee' INTEGER,
+  'TrancheKey' TEXT,
 
   -- derive the difference in reserves from the previous tick state
   'derived.ReservesDiff' TEXT NOT NULL,


### PR DESCRIPTION
There are some issues with the current swap volume calculations:
- Fees may be incorrectly calculated from incorrect Fee keys from the Dex
  - resolution: add better restrictions on Fee values accepted, fees on tranches are not valid

- Where Fees are `null` the calculated fee volume may return `null` instead of `0`
  - resolution: set `null` values to `0` in calculations
- Volume currently includes token reserves placed in tranches without any swap execution
  - resolution: track volume by the swapped tokens out of limit orders, which better represent executed volume